### PR TITLE
Initial release on main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,5 @@
+upload_without_merge: True
+
+upload_to_staging_channel_in_pr: False
+
+channels: [cuda12_def]

--- a/abs.yaml
+++ b/abs.yaml
@@ -3,3 +3,5 @@ upload_without_merge: True
 upload_to_staging_channel_in_pr: False
 
 channels: [cuda12_def]
+
+aggregate_check: false

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,7 +1,1 @@
-upload_without_merge: True
-
-upload_to_staging_channel_in_pr: False
-
-channels: [cuda12_def]
-
 aggregate_check: false


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-5951](https://anaconda.atlassian.net/browse/PKG-5951) 
- [Upstream repository](https://github.com/conda-forge/nvtx-c-feedstock)

### Explanation of changes:

- Dependency for pytorch-cuda 2.5.1, which needs to be built for python 3.13.
- Not sure how the other python variants of python 3.13 were built, maybe this was in a local channel
- Recipe just pulled from conda-forge, no changes necessary from theirs. Please check the main branch
- Will add pinning to aggregate once approved


[PKG-5951]: https://anaconda.atlassian.net/browse/PKG-5951?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ